### PR TITLE
add fix for d3 load and dom wrapper

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -6,11 +6,12 @@
 <script src="http://www.patternfly.org/components/jquery/dist/jquery.min.js"></script>
 <script src="http://www.patternfly.org/components/bootstrap/dist/js/bootstrap.min.js"></script>
 <script src="http://www.patternfly.org/components/patternfly/dist/js/patternfly.min.js"></script>
-<script src="http://www.patternfly.org/components/c3/c3.min.js"></script>
 <script src="http://www.patternfly.org/components/d3/d3.min.js"></script>
+<script src="http://www.patternfly.org/components/c3/c3.min.js"></script>
 <div id="bar-chart"></div>
 <div><label for="nterms">Number of words to show: </label><input id="nterms" name="nterms" type="number" value="10"/></div>
 <script>
+$(function() {
   var c3ChartDefaults = $().c3ChartDefaults();
 
   var categories = [ "{{ categories }}" ];
@@ -60,7 +61,7 @@
      var data = loadData();
   }, 10000);
 
-
+});
 
 </script>
 </body>


### PR DESCRIPTION
This change is addressing an issue[1] that has crept into the upstream
c3 library.

* change the order of loading to ensure d3 is loaded before c3
* add a wrapper around script to ensure that dom is loaded before
processing

[1]: c3js/c3#2060